### PR TITLE
add ILRe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1785,6 +1785,8 @@ If you find our repository and survey useful for your research, please consider 
 96. [**LongCodeZip: Compress Long Context for Code Language Models.**](https://arxiv.org/abs/2510.00446) _Yuling Shi, Yichun Qian, Hongyu Zhang, Beijun Shen, Xiaodong Gu._ ASE 2025.
 [![GitHub Repo stars](https://img.shields.io/github/stars/YerbaPage/LongCodeZip)](https://github.com/YerbaPage/LongCodeZip)
 
+97. [**ILRe: Intermediate Layer Retrieval for Context Compression in Causal Language Models.**](https://arxiv.org/abs/2508.17892) _Manlai Liang, Mandi Liu, Jiangzhou Ji, Huaijun Li, Haobo Yang, Yaohan He, Jinlong Li._ Arxiv 2025.
+
 #### 9.2 Model
 
 1. [**DSFormer: Effective Compression of Text-Transformers by Dense-Sparse Weight Factorization.**](https://arxiv.org/abs/2312.13211) _Rahul Chand, Yashoteja Prabhu, Pratyush Kumar._ Arxiv 2023.


### PR DESCRIPTION
ILRe: Intermediate Layer Retrieval for Context Compression in Causal Language Models
[Manlai Liang](https://arxiv.org/search/cs?searchtype=author&query=Liang,+M), [Mandi Liu](https://arxiv.org/search/cs?searchtype=author&query=Liu,+M), [Jiangzhou Ji](https://arxiv.org/search/cs?searchtype=author&query=Ji,+J), [Huaijun Li](https://arxiv.org/search/cs?searchtype=author&query=Li,+H), [Haobo Yang](https://arxiv.org/search/cs?searchtype=author&query=Yang,+H), [Yaohan He](https://arxiv.org/search/cs?searchtype=author&query=He,+Y), [Jinlong Li](https://arxiv.org/search/cs?searchtype=author&query=Li,+J)
Large Language Models (LLMs) have demonstrated success across many benchmarks. However, they still exhibit limitations in long-context scenarios, primarily due to their short effective context length, quadratic computational complexity, and high memory overhead when processing lengthy inputs. To mitigate these issues, we introduce a novel context compression pipeline, called Intermediate Layer Retrieval (ILRe), which determines one intermediate decoder layer offline, encodes context by streaming chunked prefill only up to that layer, and recalls tokens by the attention scores between the input query and full key cache in that specified layer. In particular, we propose a multi-pooling kernels allocating strategy in the token recalling process to maintain the completeness of semantics. Our approach not only reduces the prefilling complexity from  to  and trims the memory footprint to a few tenths of that required for the full context, but also delivers performance comparable to or superior to the full-context setup in long-context scenarios. Without additional post training or operator development, ILRe can process a single  tokens request in less than half a minute (speedup ) and scores RULER- benchmark of  with model Llama-3.1-UltraLong-8B-1M-Instruct on a Huawei Ascend 910B NPU.